### PR TITLE
Added Linux support to Input-Dog

### DIFF
--- a/InputDog.gmx/scripts/inputdog_keyboard_check_direct.gml
+++ b/InputDog.gmx/scripts/inputdog_keyboard_check_direct.gml
@@ -4,8 +4,8 @@
     this will check in direct mode
     when possible (on windows)
 */
-
-if(os_type == os_macosx)
+  
+if(os_windows)
+    return keyboard_check_direct(argument0);
+else
     return keyboard_check(argument0);
-    
-return keyboard_check_direct(argument0);


### PR DESCRIPTION
Changed the if statement in inputdog_keyboard_check_direct to check for windows before using keyboard_check_direct so that Linux works along with OSX.
